### PR TITLE
Updated for python 3.9

### DIFF
--- a/applehealthdata.py
+++ b/applehealthdata.py
@@ -138,7 +138,7 @@ class HealthDataExtractor(object):
             self.data = ElementTree.parse(f)
             self.report('done')
         self.root = self.data._root
-        self.nodes = self.root.getchildren()
+        self.nodes = list(self.root)
         self.n_nodes = len(self.nodes)
         self.abbreviate_types()
         self.collect_stats()


### PR DESCRIPTION
change line 141 to work with python 3.9 


get children has been removed in python 3.9
https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren